### PR TITLE
[Feature] [BugFix] 전환 신청 목록 조회 0.3.2, 포인트 내역 조회 0.1.3, 전환 신청 목록 조건 조회 0.1.1, 전환 신청 단건 상세 조회 0.2.4

### DIFF
--- a/src/apis/PointAPI.js
+++ b/src/apis/PointAPI.js
@@ -1,4 +1,4 @@
-import { GET_EXCHANGES, GET_EXCHANGE, GET_USER_EXCHANGES, GET_EXCHANGE_DETAIL_U, PUT_EXCHANGES, POST_EXCHANGES, GET_POINTS_HISTORY } from '../modules/PointModule';
+import { GET_EXCHANGE, GET_USER_EXCHANGES, GET_EXCHANGE_DETAIL_U, PUT_EXCHANGES, POST_EXCHANGES, GET_POINTS_HISTORY, GET_ADMIN_EXCHANGES } from '../modules/PointModule';
 import axios from "axios";
 
 
@@ -32,7 +32,7 @@ export const pointExchangeAPI = ({formdata}) => {
     }
 }
 
-export const exchangesAPI = () => {
+export const adminExchangesAPI = () => {
     const requestURL = 'http://localhost:8001/exchanges';
 
     return async (dispatch, getState) => {
@@ -47,7 +47,7 @@ export const exchangesAPI = () => {
 
             console.log('[PointAPI] exchangesAPI RESULT : ', response);
             if(response.status === 200){
-                dispatch({type: GET_EXCHANGES, payload: response.data});
+                dispatch({type: GET_ADMIN_EXCHANGES, payload: response.data});
             }
         });
 
@@ -78,7 +78,7 @@ export const userExchangesAPI = (memberCode) => {
 
 export const exchangeDetailAPI = ({exchangeCode}) => {
     console.log('요청 직전 코드 확인 : ', exchangeCode);
-    const requestURL = `http://localhost:8001/exchanges/${exchangeCode}`;
+    const requestURL = `http://localhost:8001/exchanges/${exchangeCode}/detail`;
 
     return async (dispatch, getState) => {
         const result = await axios.get(requestURL, {
@@ -174,6 +174,26 @@ export const myPointsHistoryAPI = (memberCode) => {
             console.log('PointAPI myPointsHistoryAPI RESULT : ', response);
             if(response.status === 200){
                 dispatch({type: GET_POINTS_HISTORY, payload: response.data});
+            }
+        });
+    }
+}
+
+export const exchangeStatusAPI = ({status, exchangeCode, currentPage}) => {
+    console.log("API status 확인 : ", status);
+    const requestURL = `http://localhost:8001/exchanges/${status}`;
+
+    return async (dispatch, getState) => {
+        await axios.get(requestURL, {
+            headers: {
+                "Content-Type" : "application/json",
+                "Accept" : "*/*"
+            }
+        })
+        .then(function(response){
+            console.log('PointAPI exchangeStatusAPI RESULT : ', response);
+            if(response.status === 200){
+                dispatch({type: GET_ADMIN_EXCHANGES, payload: response.data});
             }
         });
     }

--- a/src/assets/css/common.css
+++ b/src/assets/css/common.css
@@ -1637,6 +1637,7 @@
   .pagination li {
     background: var(--color-white);
     list-style: none;
+    cursor: pointer;
   }
   .pagination li a {
     text-decoration: none;

--- a/src/component/points/items/PointModal.js
+++ b/src/component/points/items/PointModal.js
@@ -10,7 +10,7 @@ function PointModal({exchangeCode, closeModal}){
 
     console.log("모달에 들어온 코드 확인 : ", exchangeCode);
     const dispatch = useDispatch();
-    const detail = useSelector(state => state.exchangeReducer);
+    const detail = useSelector(state => state.modalReducer);
     console.log("detail 확인 : ", detail);
     const date1 = new Date(detail.exchangeDate);
     const exchangeDate = date1.getFullYear() + "년 " + (date1.getMonth()+1) + "월 " + date1.getDate() + "일";

--- a/src/component/points/lists/MyPointList.js
+++ b/src/component/points/lists/MyPointList.js
@@ -4,14 +4,12 @@ import "../../../assets/css/userexchange.css";
 import { useDispatch, useSelector } from "react-redux";
 import { useEffect, useState } from "react";
 import { myPointsHistoryAPI } from "../../../apis/PointAPI";
-import { useNavigate } from "react-router-dom";
 import PointModal from "../items/PointModal";
 
 
 function MyPointList(){
 
     const dispatch = useDispatch();
-    const navigate = useNavigate();
 
     const token = window.localStorage.getItem('token');
     const decodedPayload = JSON.parse(atob(token.split('.')[1]));

--- a/src/component/points/lists/MyPointList.js
+++ b/src/component/points/lists/MyPointList.js
@@ -51,6 +51,18 @@ function MyPointList(){
         }
     };
 
+    const [currentPage, setCurrentPage] = useState(1);
+    const itemsPerPage = 5;
+    const indexOfLastItem = currentPage * itemsPerPage;
+    const indexOfFirstItem = indexOfLastItem - itemsPerPage;
+    const currentItems = myPoints && myPoints.length > 0 ? myPoints.slice(indexOfFirstItem, indexOfLastItem) : [];
+    const totalItems = myPoints.length;
+    const totalPages = Math.ceil(totalItems / itemsPerPage);
+    const handlePageChange = (newPage) => {
+        if (newPage >= 1 && newPage <= totalPages) {
+            setCurrentPage(newPage);
+        }
+    };
 
     return(
         myPoints && (
@@ -72,7 +84,7 @@ function MyPointList(){
                             </tr>
                         </thead>
                         <tbody>
-                            {Array.isArray(myPoints) && myPoints.map(
+                            {Array.isArray(currentItems) && currentItems.map(
                                 (points) => (
                                     <tr key={points.code} onClick={() => {onClickHandler(points.status, points.code)}}>
                                         <td>{formatExchangeDate(points.changeDate)}</td>
@@ -86,6 +98,20 @@ function MyPointList(){
                             )}
                         </tbody>
                     </table>
+                    <ul className="pagination">
+                    <li className="icon" onClick={() => handlePageChange(currentPage -1)}><a><span className="fas fa-angle-left">&lt;</span></a></li>
+                    {Array.from({ length: totalPages }, (_, index) => (
+                        <li
+                            key={index}
+                            onClick={() => handlePageChange(index + 1)}
+                        >
+                            <a className={currentPage === index + 1 ? "active" : ""}>
+                                {index + 1}
+                            </a>
+                        </li>
+                    ))}
+                    <li onClick={() => handlePageChange(currentPage + 1)}><a><span className="fas fa-angle-left">&gt;</span></a></li>
+                    </ul>
                 </div>
                 {isModalOpen && 
                     <PointModal exchangeCode={selectedCode} closeModal={closeModal} />

--- a/src/component/points/lists/PointExchangeList.js
+++ b/src/component/points/lists/PointExchangeList.js
@@ -2,7 +2,7 @@ import "../../../assets/css/reset.css";
 import "../../../assets/css/common.css";
 import "../../../assets/css/adminexchange.css";
 import { useDispatch, useSelector } from "react-redux";
-import { useLocation, useNavigate, useParams } from "react-router-dom";
+import { useNavigate, useParams } from "react-router-dom";
 import { adminExchangesAPI, exchangeStatusAPI, userExchangesAPI } from '../../../apis/PointAPI'
 import { useEffect, useState } from "react";
 import PointModal from "../items/PointModal";
@@ -12,7 +12,6 @@ function PointExchangeList(){
 
     const navigate = useNavigate();
     const dispatch = useDispatch();
-    const location = useLocation();
     const params = useParams();
     const exchanges = useSelector(state => state.exchangeReducer);
     const [currentPage, setCurrentPage] = useState(1);
@@ -57,24 +56,6 @@ function PointExchangeList(){
         const selectedValue = e.target.value;
         setStatusValue(selectedValue);
     }
-    useEffect(
-        () => {
-            console.log("setStatus 확인 : ", statusValue);
-
-            if(statusValue != '전체'){
-                dispatch(exchangeStatusAPI({
-                    status: statusValue,
-                    exchangeCode: params.exchangeCode,
-                    currentPage: 1
-                }));
-            } else {
-                dispatch(adminExchangesAPI({
-                    exchangeCode: params.exchangeCode,
-                    currentPage: 1
-                }))
-            }
-        },[statusValue]
-    )
 
     useEffect(
         () => {
@@ -83,11 +64,19 @@ function PointExchangeList(){
                     exchangeCode: params.exchangeCode
                 }));
             } else if(memberAuth == "ROLE_ADMIN"){
-                dispatch(adminExchangesAPI({
-                    exchangeCode: params.exchangeCode
-                }));
+                if(statusValue == '전체' || statusValue == null){
+                    dispatch(adminExchangesAPI({
+                        exchangeCode: params.exchangeCode
+                    }));
+                } else {
+                    dispatch(exchangeStatusAPI({
+                        status: statusValue,
+                        exchangeCode: params.exchangeCode,
+                        currentPage: 1
+                    }));
+                }              
             }
-        }, []
+        }, [statusValue]
     );
 
     const indexOfLastItem = currentPage * itemsPerPage;

--- a/src/component/points/lists/PointExchangeList.js
+++ b/src/component/points/lists/PointExchangeList.js
@@ -2,8 +2,8 @@ import "../../../assets/css/reset.css";
 import "../../../assets/css/common.css";
 import "../../../assets/css/adminexchange.css";
 import { useDispatch, useSelector } from "react-redux";
-import { useNavigate, useParams } from "react-router-dom";
-import { exchangesAPI, userExchangesAPI } from '../../../apis/PointAPI'
+import { useLocation, useNavigate, useParams } from "react-router-dom";
+import { adminExchangesAPI, exchangeStatusAPI, userExchangesAPI } from '../../../apis/PointAPI'
 import { useEffect, useState } from "react";
 import PointModal from "../items/PointModal";
 
@@ -12,8 +12,11 @@ function PointExchangeList(){
 
     const navigate = useNavigate();
     const dispatch = useDispatch();
+    const location = useLocation();
     const params = useParams();
     const exchanges = useSelector(state => state.exchangeReducer);
+    const [currentPage, setCurrentPage] = useState(1);
+    const itemsPerPage = 10;
 
     const token = window.localStorage.getItem('token');
     const decodedPayload = JSON.parse(atob(token.split('.')[1]));
@@ -33,25 +36,72 @@ function PointExchangeList(){
             setSelectedCode(exchangeCode);
             setIsModalOpen(true);
         } else if(memberAuth == "ROLE_ADMIN"){
-            navigate(`/exchangeDetail/${exchangeCode}`, {replace: false});
+            navigate(`/exchangeDetail/${exchangeCode}`);
         }
     };
+
+    const adminControl = () => {
+        if(memberAuth == "ROLE_ADMIN"){
+            return(
+                <select onChange={onChangeHandler} style={{width: "100px"}}>
+                    <option>전체</option>
+                    <option>대기</option>
+                    <option>승인</option>
+                    <option>반려</option>
+                </select>
+            );
+        } else { return <div></div>; }
+    };
+    const [statusValue, setStatusValue] = useState(null);
+    const onChangeHandler = (e) => {
+        const selectedValue = e.target.value;
+        setStatusValue(selectedValue);
+    }
+    useEffect(
+        () => {
+            console.log("setStatus 확인 : ", statusValue);
+
+            if(statusValue != '전체'){
+                dispatch(exchangeStatusAPI({
+                    status: statusValue,
+                    exchangeCode: params.exchangeCode,
+                    currentPage: 1
+                }));
+            } else {
+                dispatch(adminExchangesAPI({
+                    exchangeCode: params.exchangeCode,
+                    currentPage: 1
+                }))
+            }
+        },[statusValue]
+    )
 
     useEffect(
         () => {
             if(memberAuth == "ROLE_USER"){
                 dispatch(userExchangesAPI(memberCode,{
-                    exchangeCode: params.exchangeCode,
-                    currentPage: 1
+                    exchangeCode: params.exchangeCode
                 }));
             } else if(memberAuth == "ROLE_ADMIN"){
-                dispatch(exchangesAPI({
-                    exchangeCode: params.exchangeCode,
-                    currentPage: 1
+                dispatch(adminExchangesAPI({
+                    exchangeCode: params.exchangeCode
                 }));
             }
         }, []
     );
+
+    const indexOfLastItem = currentPage * itemsPerPage;
+    const indexOfFirstItem = indexOfLastItem - itemsPerPage;
+    const currentItems = exchanges && exchanges.length > 0 ? exchanges.slice(indexOfFirstItem, indexOfLastItem) : [];
+
+    const totalItems = exchanges.length;
+    const totalPages = Math.ceil(totalItems / itemsPerPage);
+
+    const handlePageChange = (newPage) => {
+        if (newPage >= 1 && newPage <= totalPages) {
+            setCurrentPage(newPage);
+        }
+    };
 
     const statusColor = (status) => {
         return status === '대기' ? '#1D7151' :
@@ -70,7 +120,10 @@ function PointExchangeList(){
         exchanges && (
             <>
                 <div>
-                    <p style={{color:"black", textAlign:"right"}}>총 신청 수 : {exchanges.length}</p>
+                    <div style={{display: "flex", justifyContent: "space-between"}}>
+                        {adminControl()}
+                        <a style={{color:"black", textAlign:"right"}}>총 신청 수 : {exchanges.length} </a>
+                    </div>
                     <table>
                         <colgroup>
                             <col width="20%"/>
@@ -87,7 +140,7 @@ function PointExchangeList(){
                             </tr>
                         </thead>
                         <tbody>
-                            {Array.isArray(exchanges) && exchanges.map(
+                            {Array.isArray(currentItems) && currentItems.map(
                                 (exchange) => (
                                     <tr key={exchange.exchangeCode} onClick={() => {onClickHandler(exchange.exchangeCode)}}>
                                         <td>{exchange.exchangeCode}</td>
@@ -99,9 +152,23 @@ function PointExchangeList(){
                             )}                 
                         </tbody>
                     </table>
+                    <ul className="pagination">
+                    <li className="icon" onClick={() => handlePageChange(currentPage -1)}><a><span className="fas fa-angle-left">&lt;</span></a></li>
+                    {Array.from({ length: totalPages }, (_, index) => (
+                        <li
+                            key={index}
+                            onClick={() => handlePageChange(index + 1)}
+                        >
+                            <a className={currentPage === index + 1 ? "active" : ""}>
+                                {index + 1}
+                            </a>
+                        </li>
+                    ))}
+                    <li onClick={() => handlePageChange(currentPage + 1)}><a><span className="fas fa-angle-left">&gt;</span></a></li>
+                    </ul>
                 </div>
                 {isModalOpen && 
-                    <PointModal exchangeCode={selectedCode} closeModal={closeModal} />
+                    <PointModal exchangeCode={selectedCode} closeModal={closeModal}/>
                 }
             </>
         )

--- a/src/modules/PointModule.js
+++ b/src/modules/PointModule.js
@@ -3,7 +3,7 @@ import { createAction, handleActions } from "redux-actions";
 const initialState = [];
 
 export const POST_EXCHANGES = 'exchange/POST_EXCHANGES';
-export const GET_EXCHANGES = 'exchange/GET_EXCHANGES';
+export const GET_ADMIN_EXCHANGES = 'exchange/GET_ADMIN_EXCHANGES';
 export const GET_EXCHANGE = 'exchange/GET_EXCHANGE';
 export const GET_USER_EXCHANGES = 'exchange/GET_USER_EXCHANGES';
 export const GET_EXCHANGE_DETAIL_U = 'exchange/GET_EXCHANGE_DETAIL_U';
@@ -12,7 +12,7 @@ export const GET_POINTS_HISTORY = 'exchange/GET_POINTS_HISTORY';
 
 const actions = createAction({
     [POST_EXCHANGES]: () => {},
-    [GET_EXCHANGES]: () => {},
+    [GET_ADMIN_EXCHANGES]: () => {},
     [GET_EXCHANGE]: () => {},
     [GET_USER_EXCHANGES]: () => {},
     [GET_EXCHANGE_DETAIL_U]: () => {},
@@ -20,21 +20,18 @@ const actions = createAction({
     [GET_POINTS_HISTORY]: () => {}
 });
 
-const exchangeReducer = handleActions(
+export const exchangeReducer = handleActions(
     {
         [POST_EXCHANGES]: (state, {payload}) => {
             return payload;
         },
-        [GET_EXCHANGES]: (state, {payload}) => {
+        [GET_ADMIN_EXCHANGES]: (state, {payload}) => {
             return payload;
         },
         [GET_EXCHANGE]: (state, {payload}) => {
             return payload;
         },
         [GET_USER_EXCHANGES]: (state, {payload}) => {
-            return payload;
-        },
-        [GET_EXCHANGE_DETAIL_U]: (state, {payload}) => {
             return payload;
         },
         [PUT_EXCHANGES]: (state, {payload}) => {
@@ -47,4 +44,11 @@ const exchangeReducer = handleActions(
     initialState
 );
 
-export default exchangeReducer;
+export const modalReducer = handleActions(
+    {
+        [GET_EXCHANGE_DETAIL_U]: (state, {payload}) => {
+            return payload;
+        }
+    },
+    initialState
+);

--- a/src/modules/index.js
+++ b/src/modules/index.js
@@ -2,7 +2,7 @@ import { combineReducers } from 'redux';
 import campaignReducer from './CampaignModule'
 import reviewReducer from './ReviewModule';
 import donationReducer from './DonationModule';
-import exchangeReducer from './PointModule';
+import {exchangeReducer, modalReducer} from './PointModule';
 import memberReducer from './MemberModule';
 
 const rootReducer = combineReducers({
@@ -10,6 +10,7 @@ const rootReducer = combineReducers({
     reviewReducer,
     donationReducer,
     exchangeReducer,
+    modalReducer,
     memberReducer
 });
 


### PR DESCRIPTION
## PR 유형 분류

- [x]  버그픽스
- [x]  기능 추가 또는 수정
- [x]  코드 작성 방식 또는 변수명 수정
- [ ]  리팩토링(기능, API 변경 없음)
- [ ]  빌드 관련 수정
- [ ]  설정파일 관련 수정
- [ ]  docs 관련 수정
- [ ]  기타 유형

## 이번 PR의 주요 변경 사항(직접 서술 또는 링크 첨부)
- 회원 신청 내역 조회, 포인트 내역 조회 시 모달 열면 리스트 사라지는 문제 -> (모듈)리듀서를 분리하여 해결
- 관리자 목록 조히 상태별로 보기 -> select 태그와 조회 API를 추가하여 기능 구현
- 회원 포인트 내역, 신청 내역, 관리자 신청 내역 목록 페이징 구현

- 회원 신청 내역 조회 여러 번 요청 시 복불복으로 내용이 출력/미출력 되는 문제 -> 신청 내역 컴포넌트는 하나이고, 기존 하나의 useEffect에서 회원 / 관리자 권한을 if문으로 나누어 API 요청하다가 관리자 측 조건 조회를 위해 useEffectf를 하나 더 추가하였음(조건별로 if문을 줌). 관리자 측 조회는 문제가 없으나 회원 측 조회에서만 문제가 발생하여 useEffect 문제로 추측, 조건조회에 관한 API 요청을 관리자 권한 조회에 이중 if문으로 넣어 useEffect를 하나로 합쳐서 해결!
Issue Number: close #100 , close #101
## 변경사항 관련 서술
리팩토링 하면 좋을 것 :
- 조건 조회 시 상세 조회 후 목록으로 돌아왔을 때 선택 조건 유지되게 하기
- 조건 조회 시 페이징 관련 상태 조건 선택하고 1보다 큰 페이지에 있는 상황에서 1페이지 밖에 없는 상태 조건 선택햇을 때 내용 출력되지 않는 것
## 본 PR에 대규모 변경이 포함되어 있는지 여부(있을 경우 관련 서술)

- [ ]  Yes
- [x]  No

## 기타
